### PR TITLE
fail safely if sqlite is not present

### DIFF
--- a/action.php
+++ b/action.php
@@ -76,6 +76,10 @@ class action_plugin_watchcycle extends DokuWiki_Action_Plugin {
 
         /** @var \helper_plugin_sqlite $sqlite */
         $sqlite = plugin_load('helper', 'watchcycle_db')->getDB();
+        if (!$sqlite) {
+            msg($this->getLang('error sqlite missing'), -1);
+            return;
+        }
         /* @var \helper_plugin_watchcycle $helper */
         $helper = plugin_load('helper', 'watchcycle');
 

--- a/helper/db.php
+++ b/helper/db.php
@@ -62,7 +62,7 @@ class helper_plugin_watchcycle_db extends DokuWiki_Plugin {
             $this->init();
         }
         if(!$this->sqlite) {
-            msg('watchcycle: no sqlite', -1);
+            msg($this->getLang('error sqlite missing'), -1);
             return false;
         }
         return $this->sqlite;

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -36,5 +36,6 @@ $lang['mail body'] = '%s has exceeded maintenance cycle and needs checking.';
 
 // error
 $lang['error mail'] = 'Cannot send mail to maintainer.';
+$lang['error sqlite missing'] = 'The watchcycle plugin requires the <a href="https://www.dokuwiki.org/plugin:sqlite">sqlite plugin</a> to work.';
 
 //Setup VIM: ex: et ts=4 :

--- a/syntax.php
+++ b/syntax.php
@@ -43,10 +43,13 @@ class syntax_plugin_watchcycle extends DokuWiki_Syntax_Plugin {
      * @return array Data for the renderer
      */
     public function handle($match, $state, $pos, Doku_Handler $handler){
-        /* @var DokuWiki_Auth_Plugin */
+        /* @var DokuWiki_Auth_Plugin $auth */
         global $auth;
 
-        $data = array();
+        if (!plugin_load('helper', 'sqlite')) {
+            msg($this->getLang('error sqlite missing'), -1);
+            return false;
+        }
         if (!preg_match('/~~WATCHCYCLE:[^:]+:\d+~~/', $match)) {
             msg('watchcycle: invalid syntax', -1);
             return false;
@@ -109,7 +112,7 @@ class syntax_plugin_watchcycle extends DokuWiki_Syntax_Plugin {
         /** @var \DokuWiki_Auth_Plugin $auth */
         global $auth;
 
-        /* @var \helper_plugin_watchcycle */
+        /* @var \helper_plugin_watchcycle $helper */
         $helper = plugin_load('helper', 'watchcycle');
 
         $watchcycle = p_get_metadata($ID, 'plugin watchcycle');


### PR DESCRIPTION
This fixes a fatal error when the sqlite plugin is missing or deactivated and shows an error message instead.