### PR TITLE
fix: adding width to admin.svg

### DIFF
--- a/admin.svg
+++ b/admin.svg
@@ -1,3 +1,5 @@
-<svg viewBox="0 0 24 24">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
     <path d="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z" />
 </svg>


### PR DESCRIPTION
The icon was not displayed correctly on the Admin Page, so i changed it to be like the admin.svg in https://github.com/cosmocode/sqlite

Tested with Greebo and arctic template on FF 59, IE 11 and Chrome 66